### PR TITLE
ci: add GHCR build and Dokploy deploy workflows

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -1,0 +1,36 @@
+name: Build and Deploy (Production)
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/dpuscher/code-scrobble:production
+
+      - name: Trigger Dokploy redeploy
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "${{ secrets.DOKPLOY_PRODUCTION_DEPLOY_WEBHOOK }}"

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -1,0 +1,36 @@
+name: Build and Deploy (Staging)
+
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/dpuscher/code-scrobble:staging
+
+      - name: Trigger Dokploy redeploy
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "${{ secrets.DOKPLOY_STAGING_DEPLOY_WEBHOOK }}"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 !.yarn/sdks
 !.yarn/versions
 data
+.mcp.json


### PR DESCRIPTION
## Summary

- Add `.github/workflows/build-staging.yaml`: builds and pushes `ghcr.io/dpuscher/code-scrobble:staging` to GHCR on push to `staging`, then triggers Dokploy redeploy via `DOKPLOY_STAGING_DEPLOY_WEBHOOK` secret
- Add `.github/workflows/build-production.yaml`: same pattern for `production` branch using `DOKPLOY_PRODUCTION_DEPLOY_WEBHOOK`
- Add `.mcp.json` to `.gitignore`

## Test plan

- [x] Set `DOKPLOY_STAGING_DEPLOY_WEBHOOK` GitHub secret (Dokploy dashboard → app → Deployments → Webhook)
- [ ] Merge and push to `staging` → Actions workflow triggers
- [ ] Verify image appears at `ghcr.io/dpuscher/code-scrobble:staging`
- [ ] Verify Dokploy receives webhook and redeploys `app` service
- [ ] Visit `https://staging.codescrobble.com` → app loads