### PR TITLE
fix: resolve Docker build failures with Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,12 @@ RUN apk add --no-cache git
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable && yarn allow-scripts run
 
-FROM base AS prod-deps
-WORKDIR /app
-RUN apk add --no-cache git
-COPY package.json yarn.lock .yarnrc.yml ./
-RUN yarn install --immutable --production && yarn allow-scripts run
-
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN yarn build
 
 FROM base AS runner
@@ -30,7 +25,7 @@ ENV PORT=3000
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/server.js ./server.js


### PR DESCRIPTION
## Summary

Two issues prevented the Docker image from building on Node 22:

- **Yarn 4 `--production` flag removed**: `yarn install --production` is deprecated in Yarn 4. The separate `prod-deps` stage was dropped and the `deps` stage is reused in the runner.
- **OpenSSL 3 incompatibility fixed**: webpack 4 (used by Next.js 9) uses the MD4 hash algorithm which is unsupported in OpenSSL 3 (bundled with Node 17+). Set `NODE_OPTIONS=--openssl-legacy-provider` in the builder stage to re-enable legacy provider support.

## Test plan

- [ ] Docker build completes successfully locally and in CI
- [ ] GitHub Actions build-staging workflow passes
- [ ] Image pushed to `ghcr.io/dpuscher/code-scrobble:staging`