### PR TITLE
fix: build multi-platform Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -16,6 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -28,6 +34,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/dpuscher/code-scrobble:production
 
       - name: Trigger Dokploy redeploy

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -16,6 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -28,6 +34,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/dpuscher/code-scrobble:staging
 
       - name: Trigger Dokploy redeploy


### PR DESCRIPTION
## Summary

Dokploy is running on an ARM64 host, but the CI was only building for `linux/amd64`, causing the pull to fail with:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

Adds QEMU emulation and Docker Buildx to both workflows and sets `platforms: linux/amd64,linux/arm64` so the pushed manifest covers both architectures.

## Test plan

- [ ] CI build passes for both platforms
- [ ] Dokploy successfully pulls and starts the container